### PR TITLE
Dev jihyun - 상태 저장 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ TestResults.xml
 .env
 .env.local
 
+# ChillMCP state file (user-specific)
+.chillmcp_state.json
+
 # OS
 .DS_Store
 Thumbs.db

--- a/src/state_manager.py
+++ b/src/state_manager.py
@@ -1,8 +1,11 @@
 """State management module for ChillMCP server."""
 
 import asyncio
+import json
+import os
 import random
 import time
+from pathlib import Path
 from typing import Optional
 
 from .config import Config
@@ -10,6 +13,9 @@ from .config import Config
 
 class StateManager:
     """Manages stress level and boss alert level for the AI agent."""
+
+    # State file path (in project root)
+    STATE_FILE = Path(__file__).parent.parent / ".chillmcp_state.json"
 
     def __init__(self, config: Config):
         """
@@ -19,21 +25,71 @@ class StateManager:
             config: Configuration object with boss alertness settings.
         """
         self.config = config
-        self._stress_level: int = 0  # 0-100
-        self._boss_alert_level: int = 0  # 0-5
+        # Use double underscore for true private variables
+        self.__stress_level: int = 0  # 0-100
+        self.__boss_alert_level: int = 0  # 0-5
         self._last_stress_update: float = time.time()
         self._last_boss_cooldown: float = time.time()
         self._lock = asyncio.Lock()
+        self._loading: bool = False  # Flag to prevent saving during load
+
+        # Load saved state if exists
+        self._load_state()
+
+        # Save initial state to ensure file always exists
+        self._save_state()
 
     @property
     def stress_level(self) -> int:
         """Get current stress level (0-100)."""
-        return self._stress_level
+        return self.__stress_level
+
+    @property
+    def _stress_level(self) -> int:
+        """Internal property for stress level (getter)."""
+        return self.__stress_level
+
+    @_stress_level.setter
+    def _stress_level(self, value: int) -> None:
+        """
+        Internal property for stress level (setter).
+        Automatically saves state when value changes.
+        """
+        # Clamp value to valid range
+        value = max(0, min(100, value))
+
+        # Only save if value actually changed and not during loading
+        if self.__stress_level != value and not self._loading:
+            self.__stress_level = value
+            self._save_state()
+        else:
+            self.__stress_level = value
 
     @property
     def boss_alert_level(self) -> int:
         """Get current boss alert level (0-5)."""
-        return self._boss_alert_level
+        return self.__boss_alert_level
+
+    @property
+    def _boss_alert_level(self) -> int:
+        """Internal property for boss alert level (getter)."""
+        return self.__boss_alert_level
+
+    @_boss_alert_level.setter
+    def _boss_alert_level(self, value: int) -> None:
+        """
+        Internal property for boss alert level (setter).
+        Automatically saves state when value changes.
+        """
+        # Clamp value to valid range
+        value = max(0, min(5, value))
+
+        # Only save if value actually changed and not during loading
+        if self.__boss_alert_level != value and not self._loading:
+            self.__boss_alert_level = value
+            self._save_state()
+        else:
+            self.__boss_alert_level = value
 
     async def update_stress_level(self) -> None:
         """
@@ -47,7 +103,8 @@ class StateManager:
             if elapsed_minutes >= 1.0:
                 # Increase stress by at least 1 point per minute
                 stress_increase = int(elapsed_minutes)
-                self._stress_level = min(100, self._stress_level + stress_increase)
+                # Setter automatically saves state
+                self._stress_level = self._stress_level + stress_increase
                 self._last_stress_update = current_time
 
     async def decrease_stress(self, amount: Optional[int] = None) -> int:
@@ -66,7 +123,8 @@ class StateManager:
             else:
                 amount = max(1, min(100, amount))
 
-            self._stress_level = max(0, self._stress_level - amount)
+            # Setter automatically saves state
+            self._stress_level = self._stress_level - amount
             return amount
 
     async def increase_boss_alert(self) -> bool:
@@ -80,6 +138,7 @@ class StateManager:
             # Roll the dice based on boss_alertness probability
             if random.randint(1, 100) <= self.config.boss_alertness:
                 if self._boss_alert_level < 5:
+                    # Setter automatically saves state
                     self._boss_alert_level += 1
                     return True
         return False
@@ -97,7 +156,8 @@ class StateManager:
                 # Calculate how many cooldown periods have passed
                 cooldown_periods = int(elapsed_seconds / self.config.boss_alertness_cooldown)
                 if self._boss_alert_level > 0:
-                    self._boss_alert_level = max(0, self._boss_alert_level - cooldown_periods)
+                    # Setter automatically saves state
+                    self._boss_alert_level = self._boss_alert_level - cooldown_periods
                 self._last_boss_cooldown = current_time
 
     async def check_boss_delay(self) -> float:
@@ -130,7 +190,47 @@ class StateManager:
     async def reset(self) -> None:
         """Reset state to initial values."""
         async with self._lock:
+            # Setter automatically saves state
             self._stress_level = 0
             self._boss_alert_level = 0
             self._last_stress_update = time.time()
             self._last_boss_cooldown = time.time()
+
+    def _save_state(self) -> None:
+        """Save current state to file (synchronous)."""
+        try:
+            state_data = {
+                "stress_level": self._stress_level,
+                "boss_alert_level": self._boss_alert_level
+            }
+            with open(self.STATE_FILE, 'w') as f:
+                json.dump(state_data, f, indent=2)
+        except Exception as e:
+            # Fail silently - state persistence is not critical
+            pass
+
+    def _load_state(self) -> None:
+        """Load state from file if exists (synchronous)."""
+        try:
+            if self.STATE_FILE.exists():
+                # Set loading flag to prevent auto-save during load
+                self._loading = True
+
+                with open(self.STATE_FILE, 'r') as f:
+                    state_data = json.load(f)
+
+                # Restore stress and boss alert levels
+                # Setter is called but won't save because _loading is True
+                self._stress_level = state_data.get("stress_level", 0)
+                self._boss_alert_level = state_data.get("boss_alert_level", 0)
+
+                # Reset timestamps to current time (don't accumulate time while server was off)
+                self._last_stress_update = time.time()
+                self._last_boss_cooldown = time.time()
+
+                # Done loading
+                self._loading = False
+        except Exception as e:
+            # Fail silently - if file doesn't exist or is corrupted, start fresh
+            self._loading = False
+            pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Pytest configuration and fixtures for ChillMCP tests."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_state_file():
+    """Remove state file before each test to ensure clean state."""
+    state_file = Path(__file__).parent.parent / ".chillmcp_state.json"
+
+    # Remove state file before test
+    if state_file.exists():
+        os.remove(state_file)
+
+    yield
+
+    # Clean up after test
+    if state_file.exists():
+        os.remove(state_file)


### PR DESCRIPTION
## 요약

  - 서버 재시작 시에도 스트레스 레벨과 보스 경계심 레벨이 유지되도록 상태 저장 기능 구현
  - Python property setter를 활용한 자동 상태 저장 기능 추가
  - 서버 초기화 시 상태 파일이 항상 생성되도록 보장

 ## 변경 사항

  상태 저장 기능 구현

  파일: `src/state_manager.py`

  1. JSON 기반 상태 저장 기능 추가
    - 상태 파일 경로: `.chillmcp_state.json` (프로젝트 루트)
    - `stress_level`과 `boss_alert_level`을 JSON 파일에 저장
    - 서버 초기화 시 저장된 상태 불러오기
    - 타임스탬프 리셋으로 서버 종료 중 시간 누적 방지
  2. property setter를 활용한 자동 저장 구현
    - `_stress_level`과 `_boss_alert_level`을 property setter로 변환
    - 값이 변경될 때마다 자동으로 상태 저장
    - `double underscore(__stress_level, __boss_alert_level)`로 진정한 private 변수 구현
    - 값의 유효 범위 자동 제한 (스트레스: 0-100, 보스 경계심: 0-5)
  3. 로딩 중 저장 방지 기능 추가
    - `_loading` 플래그 도입으로 상태 로드 중 저장 방지
    - 상태 복원 시 값 설정으로 인한 무한 루프 방지
  4. 상태 파일 생성 보장
    - `__init__`에서 `_load_state()` 후 `_save_state()` 호출
    - 첫 실행이나 상태 확인만 할 때도 파일 생성 보장

  상태 로드 로직:
  - 로딩 시작 전 `_loading = True` 설정
  - JSON에서 상태 값 복원
  - 타임스탬프를 현재 시간으로 리셋
  - 로딩 완료 후 `_loading = False` 설정
